### PR TITLE
LImit references to HPC to be more inclusive

### DIFF
--- a/Chap_Introduction.tex
+++ b/Chap_Introduction.tex
@@ -8,24 +8,24 @@
 \label{chap:intro}
 
 \added{ \ac{PMIx} is an application programming interface specification to provide
-High Performance Computing libraries and programming models with
-portable and well defined access to commonly needed
-distributed computing system software.
-The \ac{PMIx} community strives to define interfaces to support the most widely
-used HPC programming models and libraries.
-\ac{PMIx} gives distributed systems software providers a better understanding of what
-services can be provided to best support these programming models.
-It also encourages the implementation of \ac{PMIx} APIs which allow for
+libraries and programming models with a portable and well-defined access to commonly
+needed services in distributed and parallel computing systems.
+A typical example of such a service is the exchange of information to start a \ac{HPC} service
+or application in a portable and scalable manner.
+As such, \ac{PMIx} also gives distributed system software providers a better understanding of how
+programming models and libraries can interface with and use system-level services.
+As a specification, \ac{PMIx} also promotes the use and implementation of APIs that allow for
 portable access to these varied system software services and the
-functionalities they offer.   Although these APIs can be implemented directly by the
+functionalities they offer.
+Although these APIs can be defined and implemented directly by the
 system software components providing them, the \ac{PMIx} community
-feels the development of centralized \ac{PMIx} implementations better serves the
-HPC community.  Such implementations can interface
-with existing system software or directly implement PMIx API's which are
-not already provided by existing system software components.
-\ac{PMIx} allows programming languages and libraries to focus on their core
-competencies without having to provide their own services to provide
-services that are better provided at a system level. }
+feels that the development of shared specification better serves the
+community.
+Implementations of such a specification can interface
+with existing system software that are already compliant with \ac{PMIx} or, when not already available,
+directly implement PMIx APIs.
+As a result, \ac{PMIx} enables programming languages and libraries to focus on their core
+competencies without having to provide their own system-level services.
 
 \subsection{Background}
 \label{chap:introduction:background}


### PR DESCRIPTION
Update the very first paragraph of the introduction to reflect some of the points discussed during the call, mainly move away from a HPC oriented context to a focus on system services for distributed and parallel systems.

@dsolt Note that i ended up rephrasing more than i initially intended and am open to discuss any of my modifications.